### PR TITLE
Don't reload when exiting VR.

### DIFF
--- a/src/interface/ExitButton.js
+++ b/src/interface/ExitButton.js
@@ -24,7 +24,6 @@ export class ExitButton {
 
 		element.addEventListener('click', () => {
 			GA('ui', 'click', 'exit')
-			window.location.reload()
 		})
 
 		const scene = document.querySelector('a-scene')
@@ -41,7 +40,6 @@ export class ExitButton {
 		}, 10)
 	}
 	hide(){
-		window.location.reload()
 		this.element.classList.remove('visible')
 	}
 }


### PR DESCRIPTION
The logic is a bit weird. It doesn't sit well with our VR browser (@supermedium), we're handling it at the moment, but seems like we could remove it.